### PR TITLE
vendor:Add miatoll to official

### DIFF
--- a/octavi.devices
+++ b/octavi.devices
@@ -12,3 +12,4 @@ davinci
 tulip
 raphael
 ginkgo
+miatoll


### PR DESCRIPTION
The term #miatoll refers to an unified ROM that will run on all xiaomi (mi) snaprdragon 720G (atoll) devices

* Poco M2 pro (gram)
* Note 9s/ indian 9 pro (curtana)
* global Note 9 pro (joyeuse)
* Note 9 pro max (excalibur)
Signed-off-by: Lokesh773 <lokeshkasamneni773@gmail.com>