### PR TITLE
prebuilt: add permissions for com.google.android.settings.intelligence

### DIFF
--- a/prebuilt/common/etc/permissions/privapp-permissions-octavi-product.xml
+++ b/prebuilt/common/etc/permissions/privapp-permissions-octavi-product.xml
@@ -38,6 +38,10 @@
         <permission name="android.permission.RESET_BATTERY_STATS"/>
     </privapp-permissions>
 
+    <privapp-permissions package="com.google.android.settings.intelligence.IntelligenceApplication">
+        <permission name="android.permission.READ_DEVICE_CONFIG"/>
+    </privapp-permissions>
+
     <privapp-permissions package="com.android.systemui">
         <permission name="android.permission.CHANGE_CONFIGURATION"/>
         <permission name="android.permission.WRITE_APN_SETTINGS"/>


### PR DESCRIPTION
logs-
Unable to create application com.google.android.settings.intelligence.IntelligenceApplication: java.lang.SecurityException: Permission denial: reading from settings requires:android.permission.READ_DEVICE_CONFIG
Caused by: java.lang.SecurityException: Permission denial: reading from settings requires:android.permission.READ_DEVICE_CONFIG